### PR TITLE
make it easy to get started with development again

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ext/spec"]
 	path = ext/spec
-	url = https://github.com/pvande/Mustache-Spec.git
+	url = https://github.com/mustache/spec.git
 [submodule "pages"]
 	path = pages
 	url = git@github.com:pvande/Milk.git

--- a/Cakefile
+++ b/Cakefile
@@ -68,7 +68,7 @@ task 'spec:node', 'Creates compliance tests for the Mustache spec in Vows', ->
     test = """
            vows  = require('vows');
            equal = require('assert').equal;
-           Milk  = require('milk');
+           Milk  = require('../');
            suite = vows.describe('Mustache Specification - #{file}');
 
            tests  = #{json}['tests'];

--- a/README.md
+++ b/README.md
@@ -113,6 +113,19 @@ Milk itself is documented more completely at http://pvande.github.com/Milk
 
 The Mustache templating language is documented at http://mustache.github.com.
 
+Development
+-----------
+
+A few things to note:
+
+* This project uses submodules. To get them, run `git submodule init` and `git
+submodule update`.
+* To install the npm dependencies, run `npm install .`
+* There are a number of `cake` tasks, including ones that build the specs. To
+list the tasks, simply run `cake` in the project directory. To build the
+specs, run `cake spec:node` or `cake spec:html`.
+* To run the node.js tests, run `npm test`.
+
 Copyright
 ---------
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   "main": "./milk",
   "scripts": { "test": "vows ./test/*" },
   "dependencies": { "coffee-script": "0.9.6 || >=1.0.0" },
-  "devDependencies": { "vows": "0.5.2", "docco": "0.3.0" },
+  "devDependencies": { "vows": "0.5.11", "docco": "0.3.0" },
   "repository": { "type": "git", "url": "https://github.com/pvande/Milk.git" }
 }

--- a/test/escape_method.coffee
+++ b/test/escape_method.coffee
@@ -1,7 +1,7 @@
 vows   = require 'vows'
 assert = require 'assert'
 
-Milk = require('milk')
+Milk = require('../')
 
 suite = vows.describe 'Milk.escape'
 

--- a/test/helpers.coffee
+++ b/test/helpers.coffee
@@ -1,7 +1,7 @@
 vows   = require 'vows'
 assert = require 'assert'
 
-Milk = require('milk')
+Milk = require('../')
 
 suite = vows.describe 'Milk.helpers'
 

--- a/test/object_methods.coffee
+++ b/test/object_methods.coffee
@@ -1,7 +1,7 @@
 vows   = require 'vows'
 assert = require 'assert'
 
-Milk   = require 'milk'
+Milk   = require '../'
 
 suite = vows.describe 'Object Methods'
 

--- a/test/parse_errors_test.coffee
+++ b/test/parse_errors_test.coffee
@@ -1,7 +1,7 @@
 vows   = require 'vows'
 assert = require 'assert'
 
-Milk   = require 'milk'
+Milk   = require '../'
 
 throwsError = (error, tmpl) ->
   topic: -> (-> Milk.render tmpl)

--- a/test/partials_method.coffee
+++ b/test/partials_method.coffee
@@ -1,7 +1,7 @@
 vows   = require 'vows'
 assert = require 'assert'
 
-Milk = require('milk')
+Milk = require('../')
 
 suite = vows.describe 'Milk.escape'
 

--- a/test/partials_parameter.coffee
+++ b/test/partials_parameter.coffee
@@ -1,7 +1,7 @@
 vows   = require 'vows'
 assert = require 'assert'
 
-Milk = require('milk')
+Milk = require('../')
 
 suite = vows.describe 'Milk.escape'
 


### PR DESCRIPTION
A couple of things have happened that made running the tests a bit tricker:
- the spec submodule referenced pvande/Mustache-Spec, which is no longer on github
- the [vows](https://github.com/cloudhead/vows) version referenced in `package.json` got unpublished

I made these point to different resources. I also made a couple of other changes:
- It's easier to get started if the tests reference relative paths. No running `npm link .` or `npm install -g .` or similar. I made the tests in the repo and the tests generated by the Cakefile point to `../` instead of `milk`.
- I added a development section to the README with instructions on getting the node.js specs running.

Please let me know if I need to do anything else to get these changes merged. Thanks!
